### PR TITLE
typo in varable name

### DIFF
--- a/scripts/pyFAI-saxs
+++ b/scripts/pyFAI-saxs
@@ -138,7 +138,7 @@ def main():
             t0 = time.time()
             if fabioFile.nframes > 1:
                 integrator.integrate1d(data=fabioFile.data,
-                                nbPt=options.npt or min(fabioFile.data.shape),
+                                npt=options.npt or min(fabioFile.data.shape),
                                 dummy=options.dummy,
                                 delta_dummy=options.delta_dummy,
                                 filename=outFile,
@@ -150,7 +150,7 @@ def main():
                                 )
             else:
                 integrator.integrate1d(data=fabioFile.data,
-                                nbPt=min(fabioFile.data.shape),
+                                npt=min(fabioFile.data.shape),
                                 dummy=options.dummy,
                                 delta_dummy=options.delta_dummy,
                                 filename=outFile,


### PR DESCRIPTION
There is a typo in the varable name for number of points when calling integrate1d from the pyFAI-saxs script.