### PR TITLE
Avoid "Namespace" error message for pyFAI-recalib

### DIFF
--- a/pyFAI-src/calibration.py
+++ b/pyFAI-src/calibration.py
@@ -255,6 +255,9 @@ class AbstractCalibration(object):
                       type=float, default=None,
                       help="polarization factor, from -1 (vertical) to +1 (horizontal),"\
                       " default is None (no correction), synchrotrons are around 0.95")
+        self.parser.add_argument("-i", "--poni", dest="poni", metavar="FILE",
+              help="file containing the diffraction parameter (poni-file).",
+              default=None)
         self.parser.add_argument("-b", "--background", dest="background",
                       help="Automatic background subtraction if no value are provided",
                       default=None)
@@ -407,6 +410,9 @@ class AbstractCalibration(object):
 
         if self.calibrant is None:
             self.read_dSpacingFile(True)
+
+        if options.poni:
+            self.ai.load(options.poni)
 
         if options.wavelength:
             self.ai.wavelength = self.wavelength = 1e-10 * options.wavelength
@@ -2057,7 +2063,7 @@ refinement process.
 def calib(img, calibrant, detector, basename="from_ipython", reconstruct=False, dist=0.1, gaussian=None, interactive=True):
     """
     Procedural interfact for calibration
-    
+
     @param img: 2d array representing the calibration image
     @param calibrant: Instance of Calibrant, set-up with wavelength
     @param detector: Detector instance containing the mask

--- a/pyFAI-src/calibration.py
+++ b/pyFAI-src/calibration.py
@@ -1379,7 +1379,8 @@ and a new option which lets you choose between the original `massif` algorithm a
                       help="Keep existing control point and append new",
                       default=False, action="store_true")
 
-        options, args = self.parser.parse_args()
+        options = self.parser.parse_args()
+        args = options.args
         # Analyse aruments and options
         if (not options.poni) or (not os.path.isfile(options.poni)):
             logger.error("You should provide a PONI file as starting point !!")


### PR DESCRIPTION
pyFAI-recalib just dies with the error message. This is a patch to fix it.