### PR TITLE
Better guesses for start of calibration refinement

### DIFF
--- a/pyFAI-src/calibration.py
+++ b/pyFAI-src/calibration.py
@@ -1280,6 +1280,12 @@ decrease the value if arcs are mixed together.""", default=None)
         scores = [ (scor, pars), ]
 
         # Second attempt
+        defaults = self.initgeoRef()
+        self.geoRef = GeometryRefinement(self.data, 
+                                         detector=self.detector,
+                                         wavelength=self.wavelength,
+                                         calibrant=self.calibrant,
+                                         **defaults)
         self.geoRef.guess_poni()
         self.geoRef.refine2(1000000, fix= self.fixed)
         scor = self.geoRef.chi2()

--- a/pyFAI-src/calibration.py
+++ b/pyFAI-src/calibration.py
@@ -1274,7 +1274,6 @@ decrease the value if arcs are mixed together.""", default=None)
                                          **defaults)
         self.geoRef.refine2(1000000, fix= self.fixed)
         scor = self.geoRef.chi2()
-        print ("SCORE %s"%(str(scor)))
         pars = [getattr(self.geoRef, p) for p in self.PARAMETERS]
 
         scores = [ (scor, pars), ]


### PR DESCRIPTION
This is meant to improve the start point for refinement in pyFAI-calib.

initgeoRef - fills in default values as was done in the refine method (hopefully)

Then there are three "attempts". The first method is the one which was previously there (but inside initgeoRef). The second is that method plus geoRef.guess_poni. The third reads a poni file which happens to be in the current working directory (seems risky?). The best one is then chosen.

Testcases are still missing (use npt files ??)

Fixes #197 